### PR TITLE
Dockerfile change ubuntu to 15.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:15.04
 MAINTAINER Romans <me@nearly.guru>
 
 # This dockerfile is suitable for installing Wordpress


### PR DESCRIPTION
Addresses issue #4 by setting the ubuntu image to 15.04 since "latest" is going to send you to 16.04 which breaks the `apt-get install` commands.
